### PR TITLE
Update metadata.json to GNOME 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
 	"description": "A GNOME quick setting for turning on and off the Syncthing service and opening the Web GUI",
 	"uuid": "syncthing-toggle@rehhouari.github.com",
 	"shell-version": [
-		"46"
+		"47"
 	],
 	"settings-schema": "org.gnome.shell.extensions.syncthing-toggle",
 	"url": "https://github.com/rehhouari/gnome-shell-extension-syncthing-toggle",


### PR DESCRIPTION
Hello, 

First of all, thank you for this extension.

As I recently updated from GNOME 46 to 47, I noticed the extension wasn’t working anymore. I simply updated the "shell-version" variable in metadata.json

EDIT: I have to add that I obviously tested this change and am able to confirm everything works fine.

Regards,